### PR TITLE
Fix #7 by passing a SegmentAllocator argument for functions that return a struct value.

### DIFF
--- a/windowsapi-code-generator/src/main/java/net/codecrete/windowsapi/metadata/Method.java
+++ b/windowsapi-code-generator/src/main/java/net/codecrete/windowsapi/metadata/Method.java
@@ -26,6 +26,7 @@ public class Method {
     private Type returnType;
     private Parameter[] parameters;
     private String dll;
+    private boolean supportsAllocator;
     private boolean supportsLastError;
     private Object constantValue;
     private LazyString documentationUrl;
@@ -206,6 +207,24 @@ public class Method {
     public boolean hasReturnType() {
         assert returnType != null;
         return !(returnType instanceof Primitive primitive && primitive.kind() == PrimitiveKind.VOID);
+    }
+
+    /**
+     * Indicates if this method uses a {@code SegmentAllocator} to allocate struct return values.
+     *
+     * @return {@code true} if {@code SegmentAllocator} is supported
+     */
+    public boolean supportsAllocator() {
+        return supportsAllocator;
+    }
+
+    /**
+     * Sets if this method uses a {@code SegmentAllocator} to allocate struct return values.
+     *
+     * @param supportsAllocator {@code true} if {@code SegmentAllocator} is supported, {@code false} otherwise
+     */
+    public void setSupportsAllocator(boolean supportsAllocator) {
+        this.supportsAllocator = supportsAllocator;
     }
 
     /**

--- a/windowsapi-code-generator/src/main/java/net/codecrete/windowsapi/winmd/CustomAttributeDecoder.java
+++ b/windowsapi-code-generator/src/main/java/net/codecrete/windowsapi/winmd/CustomAttributeDecoder.java
@@ -52,6 +52,8 @@ class CustomAttributeDecoder extends Decoder {
     private static final QualifiedName NATIVE_ENCODING_ATTRIBUTE = new QualifiedName(METADATA,
             "NativeEncodingAttribute");
     private static final QualifiedName NATIVE_TYPEDEF_ATTRIBUTE = new QualifiedName(METADATA, "NativeTypedefAttribute");
+    private static final QualifiedName METADATA_TYPEDEF_ATTRIBUTE = new QualifiedName(METADATA,
+            "MetadataTypedefAttribute");
     private static final QualifiedName STRUCT_SIZE_FIELD_ATTRIBUTE = new QualifiedName(METADATA,
             "StructSizeFieldAttribute");
     private static final QualifiedName SUPPORTED_ARCHITECTURE_ATTRIBUTE = new QualifiedName(METADATA,
@@ -72,6 +74,8 @@ class CustomAttributeDecoder extends Decoder {
             (context, data) -> data.guidConstant = createGuidConstant(context.getValue()),
             NATIVE_TYPEDEF_ATTRIBUTE,
             (context, data) -> data.isTypedef = true,
+            METADATA_TYPEDEF_ATTRIBUTE,
+            (context, data) -> data.isTypedef = true,
             STRUCT_SIZE_FIELD_ATTRIBUTE,
             (context, data) -> data.structSizeField = (String) context.getValue().fixedArguments()[0].value()
     );
@@ -89,7 +93,6 @@ class CustomAttributeDecoder extends Decoder {
             new QualifiedName(METADATA, "AnsiAttribute"),
             new QualifiedName(METADATA, "AssociatedConstantAttribute"),
             new QualifiedName(METADATA, "InvalidHandleValueAttribute"),
-            new QualifiedName(METADATA, "MetadataTypedefAttribute"),
             new QualifiedName(METADATA, "RAIIFreeAttribute"),
             new QualifiedName(METADATA, "ScopedEnumAttribute"),
             new QualifiedName(METADATA, "SupportedOSPlatformAttribute"),

--- a/windowsapi-code-generator/src/main/java/net/codecrete/windowsapi/winmd/MetadataBuilder.java
+++ b/windowsapi-code-generator/src/main/java/net/codecrete/windowsapi/winmd/MetadataBuilder.java
@@ -453,7 +453,9 @@ public class MetadataBuilder implements TypeLookup {
         var methodDef = metadataFile.getMethodDef(method.methodDefIndex());
         var methodSignature =
                 signatureDecoder.decodeMethodDefSignature(metadataFile.getBlob(methodDef.signature()));
-        method.setReturnType(methodSignature.returnType());
+        var returnType = methodSignature.returnType();
+        method.setReturnType(returnType);
+        method.setSupportsAllocator(returnType instanceof Struct);
 
         var parameters = new Parameter[methodSignature.paramTypes().length];
         int index = 0;

--- a/windowsapi-code-generator/src/main/java/net/codecrete/windowsapi/writer/CommentWriter.java
+++ b/windowsapi-code-generator/src/main/java/net/codecrete/windowsapi/writer/CommentWriter.java
@@ -102,12 +102,20 @@ class CommentWriter {
                      * </p>
                 """);
 
-        if (function.supportsLastError())
+        var supportsAllocator = function.supportsAllocator();
+        var supportsLastError = function.supportsLastError();
+        if (supportsAllocator)
             writer.print("""
                          * <p>
-                         * The additional first parameter takes a memory segment to capture the call state (replacement for {@code GetLastError()}).
+                         * The additional first parameter takes a segment allocator to allocate struct return values.
                          * </p>
                     """);
+        if (supportsLastError)
+            writer.printf("""
+                         * <p>
+                         * The additional %s parameter takes a memory segment to capture the call state (replacement for {@code GetLastError()}).
+                         * </p>
+                    """, supportsAllocator ? "second" : "first");
 
         writeDocumentationUrl(writer, function);
 

--- a/windowsapi-code-generator/src/main/java/net/codecrete/windowsapi/writer/FunctionCodeWriter.java
+++ b/windowsapi-code-generator/src/main/java/net/codecrete/windowsapi/writer/FunctionCodeWriter.java
@@ -20,7 +20,9 @@ import java.util.Objects;
  */
 class FunctionCodeWriter extends FunctionCodeWriterBase<Type> {
 
-    private static final String CALL_STATE_NOTE = "The additional first parameter takes a memory segment to capture " +
+    private static final String CALL_STATE_NOTE_1 = "The additional first parameter takes a segment allocator to " +
+            "allocate struct return values.";
+    private static final String CALL_STATE_NOTE_2 = "The additional %s parameter takes a memory segment to capture " +
             "the call state (replacement for {@code GetLastError()}).";
 
     private final CommentWriter commentWriter = new CommentWriter();
@@ -150,10 +152,15 @@ class FunctionCodeWriter extends FunctionCodeWriterBase<Type> {
 
     private void writeFunctionDescriptorAndHandle(Method method) {
         var methodName = method.name();
+        var supportsAllocator = method.supportsAllocator();
+        var supportsLastError = method.supportsLastError();
+
+        var callStateNote1 = supportsAllocator ? CALL_STATE_NOTE_1 : null;
+        var callStateNote2 = supportsLastError ? String.format(CALL_STATE_NOTE_2, supportsAllocator ? "second" : "first") : null;
 
         // descriptor accessor
         writeCommentWithNotes(String.format("Gets the function descriptor for {@code %s}", method.nativeName()),
-                method.supportsLastError() ? CALL_STATE_NOTE : null);
+                callStateNote1, callStateNote2);
         writer.printf("""
                     public static FunctionDescriptor %1$s$descriptor() {
                         return %1$s$IMPL.DESC;

--- a/windowsapi-code-generator/src/main/java/net/codecrete/windowsapi/writer/FunctionCodeWriterBase.java
+++ b/windowsapi-code-generator/src/main/java/net/codecrete/windowsapi/writer/FunctionCodeWriterBase.java
@@ -84,12 +84,18 @@ class FunctionCodeWriterBase<T extends Type> extends JavaCodeWriter<T> {
      */
     protected void writeFunctionSignatureParameters(Method function) {
         var parameters = function.parameters();
-        if (function.supportsLastError())
-            writer.print("MemorySegment lastErrorState");
+        var supportsAllocator = function.supportsAllocator();
+        var supportsLastError = function.supportsLastError();
+
+        if (supportsAllocator)
+            writer.print("SegmentAllocator allocator");
+        if (supportsLastError)
+            writer.printf("%sMemorySegment lastErrorState",
+                    supportsAllocator ? ", " : "");
 
         for (int i = 0; i < parameters.length; i += 1) {
             writer.printf("%s%s %s",
-                    i > 0 || function.supportsLastError() ? ", " : "",
+                    i > 0 || supportsAllocator || supportsLastError ? ", " : "",
                     getJavaType(parameters[i].type()),
                     getJavaSafeName(parameters[i].name()));
         }
@@ -113,13 +119,16 @@ class FunctionCodeWriterBase<T extends Type> extends JavaCodeWriter<T> {
                 %1$stry {
                 %1$s    %2$s%3$s""", indent, returnWithCast, invoke);
 
+        var supportsAllocator = function.supportsAllocator();
         var supportsLastError = function.supportsLastError();
+        if (supportsAllocator)
+            writer.print("allocator");
         if (supportsLastError)
-            writer.print("lastErrorState");
+            writer.printf("%slastErrorState", supportsAllocator ? ", " : "");
 
         var parameters = function.parameters();
         for (int i = 0; i < parameters.length; i += 1) {
-            writer.print(i > 0 || supportsLastError ? ", " : "");
+            writer.print(i > 0 || supportsAllocator || supportsLastError ? ", " : "");
             writer.print(getJavaSafeName(parameters[i].name()));
         }
         writer.println(");");

--- a/windowsapi-code-generator/src/test/java/net/codecrete/windowsapi/writer/CodeWriterTest.java
+++ b/windowsapi-code-generator/src/test/java/net/codecrete/windowsapi/writer/CodeWriterTest.java
@@ -43,7 +43,7 @@ class CodeWriterTest {
                 .map(Map.Entry::getKey).toList();
         assertThat(duplicateFiles).isEmpty();
         // The following number must not change unless the metadata has been updated
-        assertThat(eventListener.filePaths).hasSize(31992);
+        assertThat(eventListener.filePaths).hasSize(31985);
     }
 
     @Test


### PR DESCRIPTION
Fixes #7.

Additionally, treat structs with the `MetadataTypedef` attribute the same way as structs with `NativeTypedef` attribute.
This in turn causes the code generator to avoid generating synthetic structs and instead generate pointers matching the actual C API.