### PR TITLE
Maintain stable element order by using LinkedHashMap / LinkedHashSet.

### DIFF
--- a/windowsapi-code-generator/src/main/java/net/codecrete/windowsapi/WindowsApiRun.java
+++ b/windowsapi-code-generator/src/main/java/net/codecrete/windowsapi/WindowsApiRun.java
@@ -22,7 +22,7 @@ import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayDeque;
 import java.util.Deque;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 /**
@@ -44,12 +44,12 @@ public class WindowsApiRun {
     private String basePackage = "";
     private EventListener eventListener = new NullEventListener();
 
-    private Set<String> structs = new HashSet<>();
-    private Set<String> functions = new HashSet<>();
-    private Set<String> enumerations = new HashSet<>();
-    private Set<String> callbackFunctions = new HashSet<>();
-    private Set<String> comInterfaces = new HashSet<>();
-    private Set<String> constants = new HashSet<>();
+    private Set<String> structs = new LinkedHashSet<>();
+    private Set<String> functions = new LinkedHashSet<>();
+    private Set<String> enumerations = new LinkedHashSet<>();
+    private Set<String> callbackFunctions = new LinkedHashSet<>();
+    private Set<String> comInterfaces = new LinkedHashSet<>();
+    private Set<String> constants = new LinkedHashSet<>();
 
     /**
      * Creates a new instance.

--- a/windowsapi-code-generator/src/main/java/net/codecrete/windowsapi/metadata/Metadata.java
+++ b/windowsapi-code-generator/src/main/java/net/codecrete/windowsapi/metadata/Metadata.java
@@ -8,7 +8,7 @@ package net.codecrete.windowsapi.metadata;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -25,13 +25,13 @@ import static java.util.stream.Collectors.toMap;
  */
 @SuppressWarnings({"java:S4274", "java:S1192"})
 public class Metadata {
-    private final Map<String, Namespace> namespaces = new HashMap<>();
+    private final Map<String, Namespace> namespaces = new LinkedHashMap<>();
     private final Namespace unnamedNamespace = new Namespace(null);
-    private final Map<Integer, Type> typesByDefinitionIndex = new HashMap<>();
-    private final Map<Integer, Method> methodsByMethodDefIndex = new HashMap<>();
+    private final Map<Integer, Type> typesByDefinitionIndex = new LinkedHashMap<>();
+    private final Map<Integer, Method> methodsByMethodDefIndex = new LinkedHashMap<>();
     private final Map<PrimitiveKind, Primitive> primitivesByKind = buildPrimitiveTypes(unnamedNamespace);
-    private final Map<Type, Pointer> pointersByType = new HashMap<>();
-    private final Map<Integer, TypeAlias> aliasesByTypeDefIndex = new HashMap<>();
+    private final Map<Type, Pointer> pointersByType = new LinkedHashMap<>();
+    private final Map<Integer, TypeAlias> aliasesByTypeDefIndex = new LinkedHashMap<>();
 
     /**
      * Creates a new instance.

--- a/windowsapi-code-generator/src/main/java/net/codecrete/windowsapi/metadata/Namespace.java
+++ b/windowsapi-code-generator/src/main/java/net/codecrete/windowsapi/metadata/Namespace.java
@@ -6,7 +6,7 @@
 //
 package net.codecrete.windowsapi.metadata;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -18,9 +18,9 @@ import java.util.Map;
 @SuppressWarnings("java:S4274")
 public class Namespace {
     private final String name;
-    private final Map<String, Type> types = new HashMap<>();
-    private final Map<String, Method> methods = new HashMap<>();
-    private final Map<String, ConstantValue> constants = new HashMap<>();
+    private final Map<String, Type> types = new LinkedHashMap<>();
+    private final Map<String, Method> methods = new LinkedHashMap<>();
+    private final Map<String, ConstantValue> constants = new LinkedHashMap<>();
 
     /**
      * Creates a new instance.

--- a/windowsapi-code-generator/src/main/java/net/codecrete/windowsapi/metadata/Struct.java
+++ b/windowsapi-code-generator/src/main/java/net/codecrete/windowsapi/metadata/Struct.java
@@ -7,7 +7,7 @@
 package net.codecrete.windowsapi.metadata;
 
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -143,7 +143,7 @@ public final class Struct extends Type {
      */
     public void addNestedType(Type nestedType) {
         if (nestedTypes == null)
-            nestedTypes = new HashMap<>();
+            nestedTypes = new LinkedHashMap<>();
         assert !nestedTypes.containsKey(nestedType.name());
         nestedTypes.put(nestedType.name(), nestedType);
     }

--- a/windowsapi-code-generator/src/main/java/net/codecrete/windowsapi/winmd/MetadataBuilder.java
+++ b/windowsapi-code-generator/src/main/java/net/codecrete/windowsapi/winmd/MetadataBuilder.java
@@ -31,7 +31,7 @@ import net.codecrete.windowsapi.winmd.tables.TypeDef;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -65,7 +65,7 @@ public class MetadataBuilder implements TypeLookup {
     private final VariantTransformation variantTransformation;
     private final Primitive[] primitiveTypes = new Primitive[15];
     private final CustomAttributeDecoder customAttributeDecoder;
-    private final Map<Integer, Namespace> apiTypes = new HashMap<>();
+    private final Map<Integer, Namespace> apiTypes = new LinkedHashMap<>();
     private final SignatureDecoder signatureDecoder;
     private final Primitive intPtrType;
     private final Primitive uintPtrType;

--- a/windowsapi-code-generator/src/main/java/net/codecrete/windowsapi/winmd/VariantTransformation.java
+++ b/windowsapi-code-generator/src/main/java/net/codecrete/windowsapi/winmd/VariantTransformation.java
@@ -17,8 +17,8 @@ import net.codecrete.windowsapi.metadata.Struct;
 import net.codecrete.windowsapi.metadata.Type;
 import net.codecrete.windowsapi.metadata.TypeAlias;
 
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -45,8 +45,8 @@ class VariantTransformation {
     private static final int ARM64_OFFSET = 1000000;
 
     private final Metadata metadata;
-    private final HashMap<String, HashMap<Integer, Type>> typeVariants = new HashMap<>();
-    private final Set<Integer> unsupportedVariants = new HashSet<>();
+    private final Map<String, Map<Integer, Type>> typeVariants = new LinkedHashMap<>();
+    private final Set<Integer> unsupportedVariants = new LinkedHashSet<>();
 
     VariantTransformation(Metadata metadata) {
         this.metadata = metadata;
@@ -77,7 +77,7 @@ class VariantTransformation {
             return false;
 
         assert type instanceof Struct || type instanceof Delegate;
-        var variants = typeVariants.computeIfAbsent(type.name(), k -> new HashMap<>());
+        var variants = typeVariants.computeIfAbsent(type.name(), k -> new LinkedHashMap<>());
         variants.put(architecture, type);
         if (type instanceof Struct struct)
             struct.setArchitectureSpecific(true);
@@ -126,7 +126,7 @@ class VariantTransformation {
      * </p>
      */
     void splitCombinedVariants() {
-        var architectureSpecificCache = new HashMap<Type, Boolean>();
+        var architectureSpecificCache = new LinkedHashMap<Type, Boolean>();
 
         // identify types that are indirectly architecture-specific
         var indirectlySpecificTypes = metadata.types()
@@ -136,8 +136,8 @@ class VariantTransformation {
                 .map(Struct.class::cast)
                 .collect(Collectors.toSet());
 
-        var x64Replacements = new HashMap<Type, Type>();
-        var arm64Replacements = new HashMap<Type, Type>();
+        var x64Replacements = new LinkedHashMap<Type, Type>();
+        var arm64Replacements = new LinkedHashMap<Type, Type>();
 
         // create two separate variants for each indirectly architecture-specific type
         for (var type : indirectlySpecificTypes) {

--- a/windowsapi-code-generator/src/main/java/net/codecrete/windowsapi/writer/AddressLayout.java
+++ b/windowsapi-code-generator/src/main/java/net/codecrete/windowsapi/writer/AddressLayout.java
@@ -20,7 +20,7 @@ import net.codecrete.windowsapi.metadata.TypeAlias;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -129,7 +129,7 @@ record AddressLayout(boolean aligned,
      * @return the required address layouts
      */
     static List<AddressLayout> requiredLayouts(Struct struct) {
-        var addressLayouts = new HashSet<AddressLayout>();
+        var addressLayouts = new LinkedHashSet<AddressLayout>();
         addLayoutsRecursively(struct, struct.packageSize(), addressLayouts);
         return filteredAndSorted(addressLayouts);
     }
@@ -141,7 +141,7 @@ record AddressLayout(boolean aligned,
      * @return the required address layouts
      */
     static List<AddressLayout> requiredLayouts(Collection<Method> functions) {
-        var addressLayouts = new HashSet<AddressLayout>();
+        var addressLayouts = new LinkedHashSet<AddressLayout>();
         functions.stream().flatMap(Method::referencedTypes).forEach(it -> addLayout(it, addressLayouts));
         return filteredAndSorted(addressLayouts);
     }

--- a/windowsapi-code-generator/src/main/java/net/codecrete/windowsapi/writer/CodeWriter.java
+++ b/windowsapi-code-generator/src/main/java/net/codecrete/windowsapi/writer/CodeWriter.java
@@ -22,7 +22,7 @@ import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 /**
@@ -135,7 +135,7 @@ public class CodeWriter extends JavaCodeWriter<Type> {
      */
     public void write(Scope scope) {
         if (!isDryRun)
-            generatedFiles = new HashSet<>();
+            generatedFiles = new LinkedHashSet<>();
         scope.getTransitiveTypeScope().forEach(this::writeType);
         scope.getFunctions().forEach(functionCodeWriter::writeFunctions);
         scope.getConstants().forEach(constantCodeWriter::writeConstants);

--- a/windowsapi-code-generator/src/main/java/net/codecrete/windowsapi/writer/Scope.java
+++ b/windowsapi-code-generator/src/main/java/net/codecrete/windowsapi/writer/Scope.java
@@ -19,7 +19,7 @@ import net.codecrete.windowsapi.metadata.Type;
 import net.codecrete.windowsapi.metadata.TypeAlias;
 
 import java.util.Collection;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -39,10 +39,10 @@ public class Scope {
     private static final String ENUMERATION_MEMBER_SINGLE = "%s Enumeration \"%s\" contains a member with that name. " +
             "Specify the enumeration instead of the constant.";
 
-    private final Set<Type> typeSet = new HashSet<>();
-    private final Set<Method> methodSet = new HashSet<>();
-    private final Set<ConstantValue> constantSet = new HashSet<>();
-    private final Set<Type> transitiveScope = new HashSet<>();
+    private final Set<Type> typeSet = new LinkedHashSet<>();
+    private final Set<Method> methodSet = new LinkedHashSet<>();
+    private final Set<ConstantValue> constantSet = new LinkedHashSet<>();
+    private final Set<Type> transitiveScope = new LinkedHashSet<>();
     private final Metadata metadata;
     private final EventListener eventListener;
     private boolean hasInvalidArguments = false;

--- a/windowsapi-code-generator/src/main/java/net/codecrete/windowsapi/writer/StructCodeWriter.java
+++ b/windowsapi-code-generator/src/main/java/net/codecrete/windowsapi/writer/StructCodeWriter.java
@@ -17,7 +17,7 @@ import net.codecrete.windowsapi.metadata.TypeAlias;
 import net.codecrete.windowsapi.winmd.LayoutRequirement;
 
 import java.util.Comparator;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -520,7 +520,7 @@ class StructCodeWriter extends JavaCodeWriter<Struct> {
     }
 
     private static Set<Struct> getUnalignedMemberStructs(Struct struct, int packageSize) {
-        var unalignedStructs = new HashSet<Struct>();
+        var unalignedStructs = new LinkedHashSet<Struct>();
         collectUnalignedMemberStructs(struct, packageSize, unalignedStructs);
         return unalignedStructs;
     }

--- a/windowsapi-maven-plugin/src/main/java/net/codecrete/windowsapi/maven/WindowsApiGenerator.java
+++ b/windowsapi-maven-plugin/src/main/java/net/codecrete/windowsapi/maven/WindowsApiGenerator.java
@@ -16,7 +16,7 @@ import org.apache.maven.project.MavenProject;
 
 import java.io.File;
 import java.nio.file.Path;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 
 /**
@@ -151,17 +151,17 @@ public class WindowsApiGenerator extends AbstractMojo {
         run.setEventListener(new EventLogger(getLog()));
 
         if (functions != null)
-            run.setFunctions(new HashSet<>(functions));
+            run.setFunctions(new LinkedHashSet<>(functions));
         if (structs != null)
-            run.setStructs(new HashSet<>(structs));
+            run.setStructs(new LinkedHashSet<>(structs));
         if (enumerations != null)
-            run.setEnumerations(new HashSet<>(enumerations));
+            run.setEnumerations(new LinkedHashSet<>(enumerations));
         if (callbackFunctions != null)
-            run.setCallbackFunctions(new HashSet<>(callbackFunctions));
+            run.setCallbackFunctions(new LinkedHashSet<>(callbackFunctions));
         if (comInterfaces != null)
-            run.setComInterfaces(new HashSet<>(comInterfaces));
+            run.setComInterfaces(new LinkedHashSet<>(comInterfaces));
         if (constants != null)
-            run.setConstants(new HashSet<>(constants));
+            run.setConstants(new LinkedHashSet<>(constants));
 
         run.setOutputDirectory(sourceFolder);
         run.setBasePackage(basePackage != null ? basePackage : "");


### PR DESCRIPTION
This should hopefully make code generation more consistent, since otherwise HashMap/HashSet can return elements in different order between iterations.