### PR TITLE
add support for tracing downcalls

### DIFF
--- a/windowsapi-code-generator/src/main/java/net/codecrete/windowsapi/writer/FunctionCodeWriter.java
+++ b/windowsapi-code-generator/src/main/java/net/codecrete/windowsapi/writer/FunctionCodeWriter.java
@@ -89,6 +89,18 @@ class FunctionCodeWriter extends FunctionCodeWriterBase<Type> {
 
         writer.println();
 
+        writer.print("""
+                private static final boolean TRACE_DOWNCALLS = Boolean.getBoolean("windowsapi.trace.downcalls");
+
+                private static void traceDowncall(String name, Object... args) {
+                    var traceArgs = java.util.Arrays.stream(args)
+                            .map(Object::toString)
+                            .collect(java.util.stream.Collectors.joining(", "));
+                    System.out.printf("%s(%s)%n", name, traceArgs);
+                }
+
+            """);
+
         for (var method : functions)
             writeFunction(method);
 

--- a/windowsapi-code-generator/src/main/java/net/codecrete/windowsapi/writer/FunctionCodeWriterBase.java
+++ b/windowsapi-code-generator/src/main/java/net/codecrete/windowsapi/writer/FunctionCodeWriterBase.java
@@ -111,8 +111,28 @@ class FunctionCodeWriterBase<T extends Type> extends JavaCodeWriter<T> {
 
         writer.printf("""
                 %1$stry {
+                %1$s    if (TRACE_DOWNCALLS) {
+                %1$s        traceDowncall(\"%2$s\"""", indent, function.name());
+        writer.print(function.parameters().length > 0 || function.supportsLastError() ? ", " : "");
+
+        writeFunctionParameterList(function);
+        writer.println(");");
+
+        writer.printf("""
+                %1$s    }
                 %1$s    %2$s%3$s""", indent, returnWithCast, invoke);
 
+        writeFunctionParameterList(function);
+        writer.println(");");
+
+        writer.printf("""
+                %1$s} catch (Throwable ex) {
+                %1$s    throw new RuntimeException(ex);
+                %1$s}
+                """, indent);
+    }
+
+    private void writeFunctionParameterList(Method function) {
         var supportsLastError = function.supportsLastError();
         if (supportsLastError)
             writer.print("lastErrorState");
@@ -122,12 +142,5 @@ class FunctionCodeWriterBase<T extends Type> extends JavaCodeWriter<T> {
             writer.print(i > 0 || supportsLastError ? ", " : "");
             writer.print(getJavaSafeName(parameters[i].name()));
         }
-        writer.println(");");
-
-        writer.printf("""
-                %1$s} catch (Throwable ex) {
-                %1$s    throw new RuntimeException(ex);
-                %1$s}
-                """, indent);
     }
 }


### PR DESCRIPTION
Fixes #11 

Support for tracing downcalls by printing on the `stdout` the native calls and their parameters, driven by a `-Dwindowsapi.trace.downcalls=true` property setting when launching the application code using the generated bindings.

For each `Apis.java` generated class, the following definitions are added:
```java
    private static final boolean TRACE_DOWNCALLS = Boolean.getBoolean("windowsapi.trace.downcalls");

    private static void traceDowncall(String name, Object... args) {
        var traceArgs = java.util.Arrays.stream(args)
                .map(Object::toString)
                .collect(java.util.stream.Collectors.joining(", "));
        System.out.printf("%s(%s)%n", name, traceArgs);
    }
```
and for each downcall code, the `traceDowncall()` invocation is added (e.g. to native call of `CloseHandle()` function):
```java
    public static int CloseHandle(MemorySegment lastErrorState, MemorySegment hObject) {
        try {
            if (TRACE_DOWNCALLS) {
                traceDowncall("CloseHandle", lastErrorState, hObject);
            }
            return (int) CloseHandle$IMPL.HANDLE.invokeExact(lastErrorState, hObject);
        } catch (Throwable ex) {
            throw new RuntimeException(ex);
        }
    }
```
